### PR TITLE
fix a bug in get queue

### DIFF
--- a/webservice/utils/convert.py
+++ b/webservice/utils/convert.py
@@ -1,0 +1,14 @@
+import time
+import datetime
+
+
+def javaTimeTotimeStamp(commitTime):
+    commitTime = commitTime.replace('T', ' ').replace('Z',
+                                                      '')  #java time To string
+    commitTime = time.strptime(commitTime, '%Y-%m-%d %H:%M:%S')
+    dt = datetime.datetime.fromtimestamp(time.mktime(commitTime))
+    actualCreateTime = (
+        dt + datetime.timedelta(hours=8)).strftime("%Y-%m-%d %H:%M:%S")
+    timeArray = time.strptime(actualCreateTime, "%Y-%m-%d %H:%M:%S")
+    createTime = int(time.mktime(timeArray))
+    return createTime


### PR DESCRIPTION
修改获取commit提交时间的方式。
原获取是通过GitHub api获取，获得createTime不准确。因此改为PR open/synchronize时就将GitHub APP 发出的payload存入到数据库中，在将指标写到数据库时通过查表的方式来获取createTime。