### PR TITLE
Update clean logic

### DIFF
--- a/webservice/event.py
+++ b/webservice/event.py
@@ -278,7 +278,7 @@ async def check_ci_failure(event, gh, repo, *args, **kwargs):
             ]:
                 pr_num = getPRNum(pr_search_url)
                 commits_url = "https://api.github.com/repos/" + repo + "/pulls/" + str(
-                    pr_num) + "/commits"
+                    pr_num) + "/commits?per_page=250"
                 comment_list = checkComments(comment_url)
                 combined_ci_status, required_all_passed = await checkCIState(
                     combined_statuses_url, required_ci_list)
@@ -298,7 +298,7 @@ async def check_ci_failure(event, gh, repo, *args, **kwargs):
                                 await gh.post(
                                     comment_url, data={"body": message})
                                 await clean_parent_comment_list(
-                                    gh, parent_comment_url, pr_num, shortId)
+                                    gh, commits_url, pr_num, shortId)
                             else:
                                 for i in range(len(comment_list)):
                                     comment_sender = comment_list[i]['user'][
@@ -319,7 +319,7 @@ async def check_ci_failure(event, gh, repo, *args, **kwargs):
                     else:
                         await create_add_ci_failure_summary(
                             gh, context, comment_url, ci_link, shortId, pr_num,
-                            comment_list, parent_comment_url)
+                            comment_list, commits_url)
 
 
 async def create_add_ci_failure_summary(gh, context, comment_url, ci_link,
@@ -474,7 +474,7 @@ async def clean_parent_comment_list(gh, commits_url, pr_num, shortId):
                     comment_sender = commit_comments_list[j]['user']['login']
                     if comment_sender == "paddle-bot[bot]":
                         delete_url = commit_comments_list[j]['url']
-                        delete_sha = commit_comments_list[j]['commit_id']
+                        delete_sha = commit_comments_list[j]['commit_id'][0:7]
                         count += 1
                         logger.info(
                             "REMOVE: %s comment(s) from parent commit: %s; pr num: %s; current sha: %s"

--- a/webservice/event.py
+++ b/webservice/event.py
@@ -377,14 +377,16 @@ async def create_add_ci_failure_summary(gh, context, comment_url, ci_link,
                     logger.info(
                         "Successful trigger logic for CHANGE Success Comment to XLY bullet. pr num: %s"
                         % pr_num)
-                    await gh.patch(update_url, data={"body": update_message})
+                    await gh.delete(update_url)
+                    await gh.post(comment_url, data={"body": update_message})
                 else:
                     update_message = failed_header + failed_template % str(
                         shortId) + failed_ci_bullet % context
                     logger.info(
                         "Successful trigger logic for CHANGE Success Comment to TC bullet. pr num: %s"
                         % pr_num)
-                    await gh.patch(update_url, data={"body": update_message})
+                    await gh.delete(update_url)
+                    await gh.post(comment_url, data={"body": update_message})
 
 
 async def update_ci_failure_summary(gh, context, ci_link, comment_list,

--- a/webservice/event.py
+++ b/webservice/event.py
@@ -474,10 +474,11 @@ async def clean_parent_comment_list(gh, commits_url, pr_num, shortId):
                     comment_sender = commit_comments_list[j]['user']['login']
                     if comment_sender == "paddle-bot[bot]":
                         delete_url = commit_comments_list[j]['url']
+                        delete_sha = commit_comments_list[j]['commit_id']
                         count += 1
                         logger.info(
-                            "REMOVE: %s comment(s) from parent commit; pr num: %s; current sha: %s"
-                            % (count, pr_num, shortId))
+                            "REMOVE: %s comment(s) from parent commit: %s; pr num: %s; current sha: %s"
+                            % (count, delete_sha, pr_num, shortId))
                         await gh.delete(delete_url)
                     else:
                         logger.info("Comment from User: %s, stop cleaning." %

--- a/webservice/event.py
+++ b/webservice/event.py
@@ -336,17 +336,15 @@ async def create_add_ci_failure_summary(gh, context, comment_url, ci_link,
             if comment_sender == "paddle-bot[bot]" and comment_body.startswith(
                     '## 🕵️'):
                 split_body = comment_body.split("\r\n")
-                context_list = re.findall(context, comment_body)
+                context_list = re.findall(r"\">(.+?)</a></b>", comment_body)
                 if ci_link.startswith('https://xly.bce.baidu.com'):
                     IsExit = True
-                    # for j in range(len(split_body)):
                     for j in range(len(context_list)):
                         logger.info("context:%s" % context)
-                        # if context in split_body[j]:
                         if context == context_list[j]:
                             IsExit = False
                             latest_body = comment_body.replace(
-                                "\r\n" + split_body[j+2], '')
+                                "\r\n" + split_body[j + 2], '')
                             update_message = latest_body + "\r\n" + failed_ci_bullet % failed_ci_hyperlink
                             logger.info(
                                 "Successful trigger logic for REMOVING and ADDING XLY bullet. pr num: %s; sha: %s"
@@ -407,13 +405,12 @@ async def update_ci_failure_summary(gh, context, ci_link, comment_list,
         if comment_sender == "paddle-bot[bot]" and comment_body.startswith(
                 '## 🕵️'):
             split_body = comment_body.split("\r\n")
-            context_list = re.findall(context, comment_body)
+            context_list = re.findall(r"\">(.+?)</a></b>", comment_body)
             if ci_link.startswith('https://xly.bce.baidu.com'):
                 for j in range(len(context_list)):
-                    # if context in split_body[j]:
                     if context == context_list[j]:
                         update_message = comment_body.replace(
-                            "\r\n" + split_body[j+2], '')
+                            "\r\n" + split_body[j + 2], '')
                         curr_split_body = update_message.split("\r\n")
                         if len(curr_split_body) > 2:
                             logger.info(

--- a/webservice/utils/check.py
+++ b/webservice/utils/check.py
@@ -116,6 +116,7 @@ def getPRnum(url):
     pr_num = response['items'][0]['number']
     return pr_num
 
+
 def getCommitComments(url):
     response = requests.get(url).json()
     commits_comments_list = []

--- a/webservice/utils/check.py
+++ b/webservice/utils/check.py
@@ -115,3 +115,12 @@ def getPRnum(url):
     response = requests.get(url).json()
     pr_num = response['items'][0]['number']
     return pr_num
+
+def getCommitComments(url):
+    response = requests.get(url).json()
+    commits_comments_list = []
+    for i in range(len(response)):
+        commit_comments_url = response[i]['url'] + "/comments"
+        commit_comments = checkComments(commit_comments_url)
+        commits_comments_list.append(commit_comments)
+    return commits_comments_list


### PR DESCRIPTION
改进清理旧commit评论的逻辑：
    原本的逻辑只能删除parent commit的评论，当出现一次push大于两个commit的情况就无能为力了
    而且如果pr只有一个commit，会删除merged commit中的评论，没有必要
新逻辑：
    收集整个pr中所有commit的comments，一一清理，最后能避免之前的问题，而且不会进行多余的操作