### PR TITLE
monitor

### DIFF
--- a/webservice/monitor/gitCloneMonitor.py
+++ b/webservice/monitor/gitCloneMonitor.py
@@ -1,0 +1,112 @@
+import json
+import requests
+import datetime
+import time
+import os
+import sys
+sys.path.append("..")
+from utils.auth_ipipe import Get_ipipe_auth
+from utils.mail import Mail
+
+
+def runningJob_GitCloneTimeMonitor():
+    with open("../buildLog/running_task.json", 'r') as load_f:
+        all_waiting_task = json.load(load_f)
+        load_f.close()
+    CloneTime = []
+    for task in all_waiting_task:
+        targetId = task['targetId']
+        commitId = task['commitId']
+        CIName = task['CIName']
+        stage_url = 'https://xly.bce.baidu.com/open-api/ipipe/agile/pipeline/v1/pipelineBuild/%s' % targetId
+        session, req = Get_ipipe_auth(stage_url)
+        try:
+            res = session.send(req).json()
+        except Exception as e:
+            print("Error: %s" % e)
+        else:
+            jobGroupBuildBeans = res['pipelineBuildBean']['stageBuildBeans'][
+                0]['jobGroupBuildBeans'][0]
+            for job in jobGroupBuildBeans:
+                jobName = job['jobName']
+                logParam = job['realJobBuild']['logUrl']
+                logUrl = "https://xly.bce.baidu.com/paddlepaddle/paddle/ibuild/auth/v2/xiaolvyun/log/downloadLog?" + logParam
+                if jobName in ['构建镜像', 'build-docker-image']:
+                    stage_name = 'docker'
+                else:
+                    stage_name = 'paddlebuild'
+                getIpipeBuildLog(stage_name, commitId, CIName, logUrl)
+                with open('../buildLog/%s_%s_%s.log' %
+                          (CIName, stage_name, commitId)) as f:
+                    line = f.readlines()
+                    #length = 10 if len(line) > 10 else len(line)
+                    for i in range(0, len(line)):
+                        if "Cloning into 'Paddle'..." in line[i]:
+                            clone_startTime = line[i].split('Cloning')[
+                                0].strip()
+                            clone_startTime = strTotimestamp(clone_startTime)
+                            start_line = i
+                            break
+                    for i in range(start_line, len(line)):
+                        if 'From https://github.com/PaddlePaddle/Paddle' in line[
+                                i]:
+                            clone_endTime = line[i].split('From')[0].strip()
+                            clone_endTime = strTotimestamp(clone_endTime)
+                            break
+                        else:
+                            clone_endTime = int(time.time())
+
+                    if clone_endTime - clone_startTime > 600:
+                        job = {}
+                        job['stage'] = stage_name
+                        job['PR'] = task['PR']
+                        job['CIName'] = task['CIName']
+                        job['commitId'] = task['commitId']
+                        job['cloneTime'] = int(
+                            (clone_endTime - clone_startTime) / 60)
+                        CloneTime.append(job)
+                    f.close()
+                os.remove("../buildLog/%s_%s_%s.log" %
+                          (CIName, stage_name, commitId))
+
+    if len(CloneTime) != 0:
+        mail_content = "<html><body><p>Hi, ALL:</p> <p>目前以下运行中的任务的gitClone时间超过10min，请注意观察代理稳定性！！</p> <table border='1' align=center> <caption><font size='3'><b>gitClone大于10min</b></font></caption>"
+        mail_content = mail_content + "<tr align=center><td bgcolor='#d0d0d0'>PR</td><td bgcolor='#d0d0d0'>CI名称</td><td bgcolor='#d0d0d0'>commitId</td><td bgcolor='#d0d0d0'>阶段名称</td><td bgcolor='#d0d0d0'>gitClone时间</td></tr>"
+        task_info = ""
+        for task in CloneTime:
+            task_info = task_info + "<tr align=center><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>".format(
+                task['PR'], task['CIName'], task['commitId'], task['stage'],
+                task['cloneTime'])
+        mail_content = mail_content + task_info + "</table></body></html>"
+        sendMonitorMail(mail_content)
+
+
+def sendMonitorMail(content):
+    mail = Mail()
+    mail.set_sender('xxxx@baidu.com')
+    mail.set_receivers(['xxxx@baidu.com'])
+    mail.set_title('gitClone时间超过10min！')
+    mail.set_message(content, messageType='html', encoding='gb2312')
+    mail.send()
+
+
+def strTotimestamp(time_str):
+    d = datetime.datetime.strptime(time_str, "%Y-%m-%d %H:%M:%S")
+    t = d.timetuple()
+    timeStamp = int(time.mktime(t))
+    return timeStamp
+
+
+def getIpipeBuildLog(typ, sha, pipelineConfName, logUrl):
+    try:
+        r = requests.get(logUrl)
+    except Exception as e:
+        print("Error: %s" % e)
+    else:
+        with open("../buildLog/%s_%s_%s.log" % (pipelineConfName, typ, sha),
+                  "wb") as f:
+            f.write(r.content)
+            f.close
+
+
+runningJob_GitCloneTimeMonitor()

--- a/webservice/monitor/last4hoursMonitor.py
+++ b/webservice/monitor/last4hoursMonitor.py
@@ -1,32 +1,8 @@
 import time
+import sys
+sys.path.append("..")
 from utils.db import Database
 from utils.mail import Mail
-
-
-def timeMonitor(startTime, endTime):
-    waitTimeMonitor = {}
-    execTimeMonitor = {}
-    commitCount = {}
-    CIMonitor = {}
-    for ci in [
-            'PR-CI-Py35', 'PR-CI-Coverage', 'PR-CI-Inference', 'PR-CI-CPU-Py2'
-    ]:
-        CIMonitor[ci] = {}
-        all_commitCount_query_stat = "SELECT COUNT(commitId) from paddle_ci_status where ciName='%s' and commit_createTime > %s and commit_createTime < %s and time > '2020-07-09 07:40:00'" % (
-            ci, startTime, endTime)
-        all_commitCount = queryDB(all_commitCount_query_stat, 'count')
-        CIMonitor[ci]['commitCount'] = all_commitCount
-        average_wait_time_query_stat = "select mean(waitTime_total)/60 from paddle_ci_status where ciName='%s' and commit_createTime > %s and commit_createTime < %s and time > '2020-07-09 07:40:00'" % (
-            ci, startTime, endTime)  #原因是这个时间点才有数据
-        average_wait_time = queryDB(average_wait_time_query_stat, 'mean')
-        CIMonitor[ci][
-            'waitTime_total'] = '%.2f' % average_wait_time if average_wait_time != None else None
-        average_exec_time_query_stat = "select mean(execTime_total)/60 from paddle_ci_status where ciName='%s' and commit_createTime > %s and commit_createTime < %s and time > '2020-07-09 07:40:00'" % (
-            ci, startTime, endTime)  #原因是这个时间点才有数据
-        average_exec_time = queryDB(average_exec_time_query_stat, 'mean')
-        CIMonitor[ci][
-            'execTime_total'] = '%.2f' % average_exec_time if average_exec_time != None else None
-    return CIMonitor
 
 
 def queryDB(query_stat, mode):
@@ -37,6 +13,29 @@ def queryDB(query_stat, mode):
     else:
         count = result[0][0][mode]
     return count
+
+
+def timeMonitor(startTime, endTime):
+    CIMonitor = {}
+    for ci in [
+            'PR-CI-Py35', 'PR-CI-Coverage', 'PR-CI-Inference', 'PR-CI-CPU-Py2'
+    ]:
+        CIMonitor[ci] = {}
+        all_commitCount_query_stat = "SELECT COUNT(commitId) from paddle_ci_status where ciName='%s' and paddle_build_endTime > %s and paddle_build_endTime < %s and time > '2020-07-09 07:40:00'" % (
+            ci, startTime, endTime)
+        all_commitCount = queryDB(all_commitCount_query_stat, 'count')
+        CIMonitor[ci]['commitCount'] = all_commitCount
+        average_wait_time_query_stat = "select mean(waitTime_total)/60 from paddle_ci_status where ciName='%s' and paddle_build_endTime > %s and paddle_build_endTime < %s and time > '2020-07-09 07:40:00'" % (
+            ci, startTime, endTime)  #原因是这个时间点才有数据
+        average_wait_time = queryDB(average_wait_time_query_stat, 'mean')
+        CIMonitor[ci][
+            'waitTime_total'] = '%.2f' % average_wait_time if average_wait_time != None else None
+        average_exec_time_query_stat = "select mean(execTime_total)/60 from paddle_ci_status where ciName='%s' and paddle_build_endTime > %s and paddle_build_endTime < %s and time > '2020-07-09 07:40:00'" % (
+            ci, startTime, endTime)  #原因是这个时间点才有数据
+        average_exec_time = queryDB(average_exec_time_query_stat, 'mean')
+        CIMonitor[ci][
+            'execTime_total'] = '%.2f' % average_exec_time if average_exec_time != None else None
+    return CIMonitor
 
 
 def alarm(ciMontor, time_stamp):
@@ -64,10 +63,30 @@ def alarm(ciMontor, time_stamp):
                 'PR-CI-Coverage', 'PR-CI-Py35', 'PR-CI-Inference',
                 'PR-CI-CPU-Py2'
         ]:
-            if index == 'waitTime_total' and float(ciMontor[ci_name][
-                    index]) > 60:
+            if index == 'waitTime_total' and ciMontor[ci_name][
+                    index] != None and float(ciMontor[ci_name][index]) > 60:
                 CI_INDEX_INFO += "<td bgcolor='#ff6eb4'>{}</td>".format(
                     ciMontor[ci_name][index])
+            elif index == 'execTime_total':
+                if ci_name == 'PR-CI-Coverage' and ciMontor[ci_name][
+                        index] != None and float(ciMontor[ci_name][
+                            index]) > 110:
+                    CI_INDEX_INFO += "<td bgcolor='#ff6eb4'>{}</td>".format(
+                        ciMontor[ci_name][index])
+                elif ci_name == 'PR-CI-Py35' and ciMontor[ci_name][
+                        index] != None and float(ciMontor[ci_name][
+                            index]) > 60:
+                    CI_INDEX_INFO += "<td bgcolor='#ff6eb4'>{}</td>".format(
+                        ciMontor[ci_name][index])
+                elif ci_name in [
+                        'PR-CI-Inference', 'PR-CI-CPU-Py2'
+                ] and ciMontor[ci_name][index] != None and float(ciMontor[
+                        ci_name][index]) > 20:
+                    CI_INDEX_INFO += "<td bgcolor='#ff6eb4'>{}</td>".format(
+                        ciMontor[ci_name][index])
+                else:
+                    CI_INDEX_INFO += "<td>{}</td>".format(ciMontor[ci_name][
+                        index])
             else:
                 CI_INDEX_INFO += "<td>{}</td>".format(ciMontor[ci_name][index])
     CI_INDEX_TABLE = CI_INDEX_TITLE + CI_NAME + CI_INDEX_INFO + "</table>"
@@ -76,9 +95,9 @@ def alarm(ciMontor, time_stamp):
 
 def mail(HTML_CONTENT):
     mail = Mail()
-    mail.set_sender('xxxxx@xxxx.com')
-    mail.set_receivers(['xxxxx@xxxx.com'])
-    mail.set_title("【告警】效率云过去4小时/过去1天CI指标")
+    mail.set_sender('xxxx@baidu.com')
+    mail.set_receivers(['xxxx@baidu.com'])
+    mail.set_title('【告警】效率云过去4小时/过去1天CI指标')
     mail.set_message(HTML_CONTENT, messageType='html', encoding='gb2312')
     mail.send()
 
@@ -93,3 +112,6 @@ def regularMonitor():
     last1dMontor_CI_INDEX_TABLE = alarm(last1dMontor, 'before 1d')
     HTML_CONTENT = last4hMontor_CI_INDEX_TABLE + last1dMontor_CI_INDEX_TABLE
     mail(HTML_CONTENT)
+
+
+regularMonitor()

--- a/webservice/monitor/queueCIMonitor.py
+++ b/webservice/monitor/queueCIMonitor.py
@@ -1,0 +1,182 @@
+import time
+import requests
+import json
+import sys
+sys.path.append("..")
+from utils.db import Database
+
+
+def queryDB(query_stat, mode):
+    db = Database()
+    result = list(db.query(query_stat))
+    if len(result) == 0:
+        count = None
+    else:
+        count = result[0][0][mode]
+    return count
+
+
+def queryDBlastHour(ci):
+    endTime = int(time.time())
+    startTime = endTime - 3600 * 2
+    execTime_last1hour_query_stat = "SELECT mean(execTime_total)/60 from paddle_ci_status where ciName='%s' and documentfix='False' and status='success' and paddle_build_endTime > %s and paddle_build_endTime < %s and time > '2020-07-09 07:40:00'" % (
+        ci, startTime, endTime)
+    execTime_last1hour = queryDB(execTime_last1hour_query_stat, 'mean')
+    if execTime_last1hour == None:
+        lastday = endTime - 3600 * 24
+        execTime_last1hour_query_stat = "SELECT mean(execTime_total)/60 from paddle_ci_status where ciName='%s' and documentfix='False' and status='success' and paddle_build_endTime > %s and paddle_build_endTime < %s and time > '2020-07-09 07:40:00'" % (
+            ci, lastday, endTime)
+        execTime_last1hour = queryDB(execTime_last1hour_query_stat, 'mean')
+    execTime_last1hour = int(execTime_last1hour)
+    return execTime_last1hour
+
+
+def getJobList(url, jobStatus):
+    V100_task_list = []
+    P4_task_list = []
+    response = requests.get(url).json()['news']
+    for t in response:
+        #if t['jobname'] != 'PADDLE_DOCKER_BUILD': #需不需要把构建镜像去掉？
+        task = {}
+        task['CIName'] = t['name']
+        task[jobStatus] = t[jobStatus] if t[jobStatus] != None else 0
+        task['PR'] = str(t['prid'])
+        task['commitId'] = t['commit']
+        task['targetId'] = t['bid']
+        if jobStatus == 'running':
+            task['jobname'] = t['jobname']
+        if t['name'].startswith('PR-CI-Py35') or t['name'].startswith(
+                'PR-CI-Coverage'):
+            V100_task_list.append(task)
+        elif t['name'].startswith('PR-CI-CPU-Py2') or t['name'].startswith(
+                'PR-CI-Inference'):
+            P4_task_list.append(task)
+    return V100_task_list, P4_task_list
+
+
+def runningCI(execTime_dict):
+    url = 'http://xxxxxx/redmine/projects.json?key=running'
+    V100_running_task, P4_running_task = getJobList(url,
+                                                    'running')  #只是从api拿到的数据
+    V100_running_task_list = []  #增加stillneedTime参数
+    P4_running_task_list = []
+    for task in V100_running_task:
+        if task['CIName'].startswith('PR-CI-Coverage'):
+            stillneedTime = execTime_dict['PR-CI-Coverage'] - task['running']
+        elif task['CIName'].startswith('PR-CI-Py35'):
+            stillneedTime = execTime_dict['PR-CI-Py35'] - task['running']
+        if stillneedTime <= 0:
+            stillneedTime = 10  #如果已经超过平均时间，统一认为还需要10min
+        task['stillneedTime'] = stillneedTime
+        V100_running_task_list.append(task)
+    for task in P4_running_task:
+        if task['CIName'].startswith('PR-CI-CPU-Py2'):
+            stillneedTime = execTime_dict['PR-CI-CPU-Py2'] - task['running']
+        elif task['CIName'].startswith('PR-CI-Inference'):
+            stillneedTime = execTime_dict['PR-CI-Inference'] - task['running']
+        if stillneedTime <= 0:
+            stillneedTime = 10  #如果已经超过平均时间，统一认为还需要10min
+        task['stillneedTime'] = stillneedTime
+        P4_running_task_list.append(task)
+    V100_running_task_list = sortTime(
+        V100_running_task_list, 'stillneedTime', reverse=False)  #按时间正序
+    P4_running_task_list = sortTime(
+        P4_running_task_list, 'stillneedTime', reverse=False)
+
+    all_running_task = V100_running_task_list + P4_running_task_list
+    all_running_task = sortTime(
+        all_running_task, 'stillneedTime', reverse=False)
+    with open("../buildLog/running_task.json", "w") as f:
+        json.dump(all_running_task, f)
+        f.close()
+    return V100_running_task_list, P4_running_task_list
+
+
+def queueUpCI():
+    url = 'http://xxxxxx/redmine/projects.json?key=waiting'
+    V100_waiting_task, P4_waiting_task = getJobList(url,
+                                                    'waiting')  #只是从api拿到的数据
+    V100_waiting_task = sortTime(V100_waiting_task, 'waiting')  #按等待时间排序
+    V100_waiting_task = forward18Task(V100_waiting_task)  #提前release18分支
+    P4_waiting_task = sortTime(P4_waiting_task, 'waiting')
+    P4_waiting_task = forward18Task(P4_waiting_task)  #提前release18分支
+
+    execTime_dict = {}
+    execTime_dict['PR-CI-Coverage'] = queryDBlastHour('PR-CI-Coverage')
+    execTime_dict['PR-CI-Py35'] = queryDBlastHour('PR-CI-Py35')
+    execTime_dict['PR-CI-CPU-Py2'] = queryDBlastHour('PR-CI-CPU-Py2')
+    execTime_dict['PR-CI-Inference'] = queryDBlastHour('PR-CI-Inference')
+    V100_running_task, P4_running_task = runningCI(execTime_dict)  #正在运行的任务
+
+    #V100任务
+    lastTaskToStartTime = 0
+    for j in range(len(V100_waiting_task)):
+        next_running_job = {}
+        for key in V100_waiting_task[j]:
+            next_running_job[key] = V100_waiting_task[j][key]
+        if next_running_job['CIName'].startswith('PR-CI-Py35'):
+            next_running_job['stillneedTime'] = execTime_dict['PR-CI-Py35']
+        elif next_running_job['CIName'].startswith('PR-CI-Coverage'):
+            next_running_job['stillneedTime'] = execTime_dict['PR-CI-Coverage']
+        V100_waiting_task[j]['timeToStart'] = V100_running_task[0][
+            'stillneedTime'] + lastTaskToStartTime
+        lastTaskToStartTime = lastTaskToStartTime + V100_running_task[0][
+            'stillneedTime']
+        for i in range(1, len(V100_running_task)):
+            new_stillneedTime = V100_running_task[i][
+                'stillneedTime'] - V100_running_task[0]['stillneedTime']
+            V100_running_task[i]['stillneedTime'] = new_stillneedTime
+        del (V100_running_task[0])
+        V100_running_task.append(next_running_job)
+        V100_running_task = sortTime(
+            V100_running_task, 'stillneedTime', reverse=False)
+
+    #P4任务
+    lastTaskToStartTime = 0
+    for j in range(len(P4_waiting_task)):
+        next_running_job = {}
+        for key in P4_waiting_task[j]:
+            next_running_job[key] = P4_waiting_task[j][key]
+        if next_running_job['CIName'].startswith('PR-CI-CPU-Py2'):
+            next_running_job['stillneedTime'] = execTime_dict['PR-CI-CPU-Py2']
+        elif next_running_job['CIName'].startswith('PR-CI-Inference'):
+            next_running_job['stillneedTime'] = execTime_dict[
+                'PR-CI-Inference']
+        P4_waiting_task[j]['timeToStart'] = P4_running_task[0][
+            'stillneedTime'] + lastTaskToStartTime
+        lastTaskToStartTime = lastTaskToStartTime + P4_running_task[0][
+            'stillneedTime']
+        for i in range(1, len(P4_running_task)):
+            new_stillneedTime = P4_running_task[i][
+                'stillneedTime'] - P4_running_task[0]['stillneedTime']
+            P4_running_task[i]['stillneedTime'] = new_stillneedTime
+        del (P4_running_task[0])
+        P4_running_task.append(next_running_job)
+        P4_running_task = sortTime(
+            P4_running_task, 'stillneedTime', reverse=False)
+
+    all_wait_task = V100_waiting_task + P4_waiting_task
+    all_wait_task = sortTime(all_wait_task, 'timeToStart', reverse=False)
+    with open("../buildLog/wait_task.json", "w") as f:
+        json.dump(all_wait_task, f)
+        f.close()
+
+
+def sortTime(task_list, key, reverse=True):
+    if len(task_list) != 0:
+        task_list = sorted(
+            task_list, key=lambda e: e.__getitem__(key), reverse=reverse)
+    return task_list
+
+
+def forward18Task(task_list):
+    task_18 = []
+    for task in task_list:
+        if '-18' in task['CIName']:
+            task_18.append(task)
+            task_list.remove(task)
+    task_list_new = task_18 + task_list
+    return task_list_new
+
+
+queueUpCI()


### PR DESCRIPTION
增加三种CI监控：
1. 过去4小时与过去1天的CI任务的排队时间/执行时间/ci任务个数。
2. 运行中的任务gitClone时间过长监控报警，作为代理的稳定性的预警。
3. 排队任务预计排队时间计算模块以及展示。