### PR TITLE
不埋点repo的效率云的基本指标的提供

### DIFF
--- a/webservice/conf/config.ini
+++ b/webservice/conf/config.ini
@@ -66,3 +66,4 @@ time_monitor = buildTime,testFluidLibTime,testFluidLibTrainTime,testCaseTime_tot
 other_monitor = fluidInferenceSize,WhlSize,buildSize,testCaseCount_total,testCaseCount_single,testCaseCount_multi,testCaseCount_exclusive
 commitCount = PaddlePaddle/Paddle,PaddlePaddle/FluidDoc
 rerun_ci_by_utfail = PR-CI-Coverage,PR-CI-Py3,PR-CI-Mac,PR-CI-Mac-Python3,PR-CI-Windows
+repo_just_xly_index = PaddlePaddle/benchmark,PaddlePaddle/FluidDoc

--- a/webservice/event.py
+++ b/webservice/event.py
@@ -168,6 +168,9 @@ async def check_close_regularly(event, gh, repo, *args, **kwargs):
 @router.register("status")
 async def check_ci_status(event, gh, repo, *args, **kwargs):
     """check_ci_status"""
+    repo_just_xly_index_list = localConfig.cf.get(
+        'ciIndex', 'repo_just_xly_index').split(
+            ',')  #这些repo没有埋点，只能拿到xly传回的时间数据
     status_dict = {}
     state = event.data['state']
     commitId = event.data['sha']
@@ -187,6 +190,8 @@ async def check_ci_status(event, gh, repo, *args, **kwargs):
                 document_fix = ifDocumentFix(commit_message)
                 if document_fix == True and context != "PR-CI-CPU-Py2":
                     EXCODE = 0
+                elif repo in repo_just_xly_index_list:
+                    EXCODE = 0 if state == 'success' else 1  #todo: branch now is default_branch
                 else:
                     index_dict = generateCiIndex(repo, commitId, target_url)
                     logger.info("target_url: %s" % target_url)

--- a/webservice/utils/analyze_buildLog.py
+++ b/webservice/utils/analyze_buildLog.py
@@ -197,8 +197,6 @@ def get_index(index_dict, sha, pipelineConfName, target_url):
     if pipelineConfName.startswith(
             'PR-CI-APPROVAL') or EXCODE == 7 or EXCODE == 2:
         pass
-    elif 'FluidDoc' in pipelineConfName:
-        pass
     else:
         buildTime_strlist = data.split('Build Time:', 1)
         buildTime = buildTime_strlist[1:][0].split('s')[0].strip()
@@ -277,23 +275,31 @@ def get_index(index_dict, sha, pipelineConfName, target_url):
             index_dict['testCaseTime_total'] = testCaseTime_mac
         elif filename.startswith('PR-CI-Windows'):
             fluidInferenceSize_strlist = data.split('FLuid_Inference Size:', 2)
-            if filename.startswith('PR-CI-Windows-OPENBLAS'):
-                fluidInferenceSize = fluidInferenceSize_strlist[2].split('M')[
-                    0].strip()
-            else:
-                fluidInferenceSize = fluidInferenceSize_strlist[2].split('G')[
-                    0].strip()
+            fluidInferenceSize = fluidInferenceSize_strlist[2].split('G')[
+                0].strip()
             index_dict['fluidInferenceSize'] = float(fluidInferenceSize)
             WhlSize_strlist = data.split('PR whl Size:', 2)
             WhlSize = WhlSize_strlist[2].split('M')[0].strip()
             index_dict['WhlSize'] = float(WhlSize)
             if not filename.startswith('PR-CI-Windows-OPENBLAS'):
+                testCaseCount_single_strlist = data.split(
+                    'Windows 1 card TestCases count is')
+                testCaseCount_single = int(testCaseCount_single_strlist[-1]
+                                           .split('\n')[0].strip())
+                index_dict['testCaseCount_single'] = testCaseCount_single
+                testCaseCount_total = testCaseCount_single
+                index_dict['testCaseCount_total'] = testCaseCount_total
+                testCaseTime_single_strlist = data.split(
+                    'Windows 1 card TestCases Total Time:')
+                testCaseTime_single = int(testCaseTime_single_strlist[1:][0]
+                                          .split('s')[0].strip())
+                index_dict['testCaseTime_single'] = testCaseTime_single
                 testCaseTime_win_strlist = data.split(
                     'Windows TestCases Total Time:')
                 testCaseTime_win = int(testCaseTime_win_strlist[1:][0].split(
                     's')[0].strip())
                 index_dict['testCaseTime_total'] = testCaseTime_win
-
+    f.close()
     if EXCODE != 7:  #build error Not in paddle_ci_index
         insertTime = int(time.time())
         query_stat = "SELECT * FROM paddle_ci_index WHERE ciName='%s' and commitId='%s' and PR=%s order by time desc" % (


### PR DESCRIPTION
1. 为不埋点的repo提供效率云的基本指标：排队时间/执行时间/状态值。
2. 不埋点repo的ci状态为成功，excode统一为0，其他为1。
3. 不埋点的repo可配置：`conf/config.ini` 中的 `repo_just_xly_index`
4. 根据https://github.com/PaddlePaddle/Paddle/pull/27492 增加统计windows的单卡case数目与执行时间。