### PR TITLE
更新预计排队时间的模块

### DIFF
--- a/webservice/conf/monitor.json
+++ b/webservice/conf/monitor.json
@@ -1,0 +1,5 @@
+{
+    "PaddlePaddle/Paddle": ["PR-CI-Coverage", "PR-CI-Py3", "PR-CI-CPU-Py2", "PR-CI-Inference", "PR-CI-Mac", "PR-CI-Mac-Python3", "PR-CI-Windows-OPENBLAS", "PR-CI-Windows", "PR-CI-APPROVAL"],
+    "PaddlePaddle/benchmark": ["PR-CI-OP-Benchmark", "PR-CI-APPROVAL"],
+    "PaddlePaddle/FluidDoc": ["FluidDoc1"]
+}

--- a/webservice/monitor/getALLCIExecTime.py
+++ b/webservice/monitor/getALLCIExecTime.py
@@ -1,0 +1,84 @@
+import json
+import time
+import sys
+sys.path.append("..")
+from utils.db import Database
+
+
+def queryDB(query_stat, mode):
+    db = Database()
+    result = list(db.query(query_stat))
+    if len(result) == 0:
+        count = None
+    else:
+        count = result[0][0][mode]
+    return count
+
+
+def queryDBlastHour(ci, repo, ifDocument):
+    """过去2h成功的耗时"""
+    endTime = int(time.time())
+    startTime = endTime - 3600 * 2
+    if ci == 'PR-CI-Mac':
+        execTime_last1hour_query_stat = "SELECT mean(execTime_total)/60 from paddle_ci_status where ciName =~ /^%s/ and ciName !~ /^PR-CI-Mac-Python3/ and repo='%s' and documentfix='%s' and status='success' and paddle_build_endTime > %s and paddle_build_endTime < %s and time > '2020-07-09 07:40:00'" % (
+            ci, repo, ifDocument, startTime, endTime)
+    elif ci == 'PR-CI-Windows':
+        execTime_last1hour_query_stat = "SELECT mean(execTime_total)/60 from paddle_ci_status where ciName =~ /^%s/ and ciName !~ /^PR-CI-Windows-OPENBLAS/ and repo='%s' and documentfix='%s' and status='success' and paddle_build_endTime > %s and paddle_build_endTime < %s and time > '2020-07-09 07:40:00'" % (
+            ci, repo, ifDocument, startTime, endTime)
+    else:
+        execTime_last1hour_query_stat = "SELECT mean(execTime_total)/60 from paddle_ci_status where ciName =~ /^%s/ and repo='%s' and documentfix='%s' and status='success' and paddle_build_endTime > %s and paddle_build_endTime < %s and time > '2020-07-09 07:40:00'" % (
+            ci, repo, ifDocument, startTime, endTime)
+    execTime_last1hour = queryDB(execTime_last1hour_query_stat, 'mean')
+    if execTime_last1hour == None:
+        lastday = endTime - 3600 * 24 * 7
+        if ci == 'PR-CI-Mac':
+            execTime_last1hour_query_stat = "SELECT mean(execTime_total)/60 from paddle_ci_status where ciName =~ /^%s/ and ciName !~ /^PR-CI-Mac-Python3/ and repo='%s' and documentfix='%s' and status='success' and paddle_build_endTime > %s and paddle_build_endTime < %s and time > '2020-07-09 07:40:00'" % (
+                ci, repo, ifDocument, lastday, endTime)
+        elif ci == 'PR-CI-Windows':
+            execTime_last1hour_query_stat = "SELECT mean(execTime_total)/60 from paddle_ci_status where ciName =~ /^%s/ and ciName !~ /^PR-CI-Windows-OPENBLAS/ and repo='%s' and documentfix='%s' and status='success' and paddle_build_endTime > %s and paddle_build_endTime < %s and time > '2020-07-09 07:40:00'" % (
+                ci, repo, ifDocument, lastday, endTime)
+        else:
+            execTime_last1hour_query_stat = "SELECT mean(execTime_total)/60 from paddle_ci_status where ciName =~ /^%s/ and repo='%s' and documentfix='%s' and status='success' and paddle_build_endTime > %s and paddle_build_endTime < %s and time > '2020-07-09 07:40:00'" % (
+                ci, repo, ifDocument, lastday, endTime)
+        execTime_last1hour = queryDB(execTime_last1hour_query_stat, 'mean')
+    if execTime_last1hour != None and int(execTime_last1hour) == 0:
+        execTime_last1hour = 2
+    else:
+        execTime_last1hour = int(
+            execTime_last1hour) if execTime_last1hour != None else None
+    return execTime_last1hour
+
+
+def getALLCIExecTime():
+    """获取所有ci的执行时间"""
+    """ciName_repo_ifDocument"""
+    execTime_dict = {}
+    with open("../conf/monitor.json", "r") as f:
+        repo_ci_dict = json.load(f)
+    for repo in repo_ci_dict:
+        for ci in repo_ci_dict[repo]:
+            if repo in ['PaddlePaddle/Paddle']:
+                if ci == 'PR-CI-CPU-Py2':
+                    for ifDocument in [True, False]:
+                        key = '%s_%s_%s' % (ci, repo, ifDocument)
+                        execTime_dict[key] = queryDBlastHour(ci, repo,
+                                                             ifDocument)
+                else:
+                    key = '%s_%s_True' % (ci, repo)
+                    execTime_dict[key] = 2
+                    key = '%s_%s_False' % (ci, repo)
+                    execTime_dict[key] = queryDBlastHour(ci, repo, 'False')
+            else:
+                ifDocument = False
+                key = '%s_%s_%s' % (ci, repo, ifDocument)
+                execTime_dict[key] = queryDBlastHour(ci, repo, ifDocument)
+    if execTime_dict[
+            'PR-CI-OP-Benchmark_PaddlePaddle/benchmark_False'] == None:
+        execTime_dict['PR-CI-OP-Benchmark_PaddlePaddle/benchmark_False'] = 15
+    execTime_dict['build-paddle_PaddlePaddle/Paddle_False'] = 15
+    with open("../buildLog/all_ci_execTime.json", "w") as f:
+        json.dump(execTime_dict, f)
+        f.close()
+
+
+getALLCIExecTime()


### PR DESCRIPTION
1. `getALLCIExecTime.py ` 40min更新一次最新两小时相同CI成功任务的平均耗时，原因是每次需要查询数据库耗时比较长，而且这个数据变化不会特别大，因此选择40min更新一次。
2. 增加benchmark与FluidDoc的预计排队时间。
3. 针对test=document_fix的commit message进行处理

TODO:
   当新增repo时，寻求更加统一的方式来计算预计排队时间。