### PR TITLE
Paddle-bot增加http服务

### DIFF
--- a/webservice/http_server.py
+++ b/webservice/http_server.py
@@ -9,7 +9,7 @@ import jinja2
 from gidgethub import routing, sansio
 from gidgethub import aiohttp as gh_aiohttp
 from utils.readConfig import ReadConfig
-from utils.test_auth_ipipe import xlyOpenApiRequest
+from utils.auth_ipipe import xlyOpenApiRequest
 from utils.auth import get_jwt, get_installation, get_installation_access_token
 
 here = Path(__file__).resolve().parent

--- a/webservice/http_server.py
+++ b/webservice/http_server.py
@@ -1,0 +1,155 @@
+from pathlib import Path
+import os
+import json
+import logging
+import aiohttp
+from aiohttp import web
+import aiohttp_jinja2
+import jinja2
+from gidgethub import routing, sansio
+from gidgethub import aiohttp as gh_aiohttp
+from utils.readConfig import ReadConfig
+from utils.test_auth_ipipe import xlyOpenApiRequest
+from utils.auth import get_jwt, get_installation, get_installation_access_token
+
+here = Path(__file__).resolve().parent
+
+localConfig = ReadConfig('conf/config.ini')
+logging.basicConfig(
+    level=logging.INFO,
+    filename='logs/auto_reun.log',
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+
+class rerunServer():
+    def __init__(self):
+        self.__rerunUrl = 'https://xly.bce.baidu.com/open-api/ipipe/agile/pipeline/doRebuild?pipeTriggerId='
+
+    def rerunCI(self, ciName, target_url):
+        """
+        1. get trigger id
+        2. rerun
+        """
+        pipelineBuildid = target_url.split('/')[-3]
+        stage_url = localConfig.cf.get('ipipeConf',
+                                       'stage_url') + pipelineBuildid
+        res = xlyOpenApiRequest().get_method(stage_url).json()
+        triggerId = res['triggerId']
+        rerun_url = self.__rerunUrl + str(triggerId)
+        query_param = 'pipeTriggerId=%s' % triggerId
+        headers = {
+            "Content-Type": "application/json",
+            "IPIPE-UID": "Paddle-bot"
+        }
+        res_status_code = xlyOpenApiRequest().get_method(
+            rerun_url, param=query_param, headers=headers).status_code
+        if res_status_code == 200:
+            print('%s_%s rerun success!' % (ciName, target_url))
+            logger.error('%s_%s rerun success!' % (ciName, target_url))
+        else:
+            print('%s_%s rerun failed: %s' %
+                  (ciName, target_url, res_status_code))
+            logger.error('%s_%s rerun failed: %s' %
+                         (ciName, target_url, res_status_code))
+
+    async def getCIList(self, user, repo, PR, commit, gh):
+        """
+        1. get commit's CI list
+        2. rerun all CI one by one
+        """
+        status_url = 'https://api.github.com/repos/%s/%s/statuses/%s' % (
+            user, repo, commit)
+        (code, header, body) = await gh._request(
+            "GET", status_url, {'Content-Type': 'application/json'})
+        res = json.loads(body.decode('utf8'))
+        REQUIRED_CI = localConfig.cf.get('%s/%s' % (user, repo), 'REQUIRED_CI')
+        commit_ci_status = []
+        for ci in res:
+            already_exit = False
+            if ci['context'] != 'license/cla':
+                for i in commit_ci_status:
+                    if ci['context'] == i['ciName'] and i['time'] > ci[
+                            'created_at']:  #删除一些脏数据 github api
+                        already_exit = True
+                        break
+                if already_exit == False and ci['context'] in REQUIRED_CI:
+                    item_dic = {}
+                    item_dic['time'] = ci['created_at']
+                    item_dic['ciName'] = ci['context']
+                    item_dic['status'] = ci['state']
+                    item_dic['target_url'] = ci['target_url']
+                    self.rerunCI(ci['context'], ci['target_url'])
+                    commit_ci_status.append(item_dic)
+        print('%s %s have been reruned!' % (PR, commit))
+        logger.info('%s %s have been reruned!' % (PR, commit))
+
+    @aiohttp_jinja2.template('reruning.html')
+    async def rerun_handler(self, request):
+        """
+        rerun get server
+        """
+        user = request.match_info['user']
+        repo = request.match_info['repo']
+        PR = request.match_info['PR']
+        commit = request.match_info['commit']
+        async with aiohttp.ClientSession() as session:
+            app_id = os.getenv("GH_APP_ID")
+            jwt = get_jwt(app_id)
+            gh = gh_aiohttp.GitHubAPI(session, user)
+            try:
+                installation = await get_installation(gh, jwt, user)
+            except ValueError as ve:
+                print(ve)
+            else:
+                access_token = await get_installation_access_token(
+                    gh, jwt=jwt, installation_id=installation["id"])
+                # treat access_token as if a personal access token
+                gh = gh_aiohttp.GitHubAPI(
+                    session, user, oauth_token=access_token["token"])
+                await self.getCIList(user, repo, PR, commit, gh)
+
+
+class failutsServer():
+    def getFailedUT(self):
+        """
+        获取失败单测列表
+        """
+        with open("buildLog/lastestfaileduts.json", 'r') as load_f:
+            try:
+                lastestfaileduts = json.load(load_f)
+            except json.decoder.JSONDecodeError:
+                lastestfaileduts = {}
+        load_f.close()
+        if len(lastestfaileduts) == 0:
+            data = {'faileduts': []}
+        else:
+            failed_uts_list = []
+            for ut in lastestfaileduts:
+                single_failed_ut = {}
+                failed_ut = ut.split('(')[0].strip()
+                failed_ut_ci_list = []
+                for task in lastestfaileduts[ut]:
+                    ci = task.split('_')[2]
+                    failed_ut_ci_list.append(ci)
+                failed_ut_ci_list = list(set(failed_ut_ci_list))
+                single_failed_ut[failed_ut] = failed_ut_ci_list
+                failed_uts_list.append(single_failed_ut)
+            data = {'faileduts': failed_uts_list}
+        return data
+
+    async def failut_handler(self, request):
+        """
+        提供失败单测的get server
+        """
+        data = self.getFailedUT()
+        return web.json_response(data)
+
+
+if __name__ == "__main__":
+    app = web.Application()
+    aiohttp_jinja2.setup(app, loader=jinja2.FileSystemLoader(str(here)))
+    app.router.add_get('/{user}/{repo}/{PR}/{commit}',
+                       rerunServer().rerun_handler)
+    app.router.add_get('/faileduts', failutsServer().failut_handler)
+    web.run_app(app, port=8081)

--- a/webservice/utils/auth_ipipe.py
+++ b/webservice/utils/auth_ipipe.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 import requests
 import base64
 import rsa
@@ -5,37 +7,65 @@ import json
 import hashlib
 import os
 
-access_id = os.getenv("IPIPE_ACCESS_ID")
-serect = os.getenv("IPIPE_SECRET")
+
+class xlyAuthorization(object):
+    """
+    效率云认证
+    """
+
+    def __init__(self):
+        self.access_id = os.getenv("IPIPE_ACCESS_ID")
+        self.serect = os.getenv("IPIPE_SECRET")
+        self.session = requests.Session()
+
+    def encrypt(self, pub, original_text):
+        """公钥加密"""
+        pub = rsa.PublicKey.load_pkcs1_openssl_pem(pub)
+        crypt_text = rsa.encrypt(bytes(original_text.encode('utf-8')), pub)
+        return crypt_text  # 加密后的密文
+
+    def query_2_md5(self, param):
+        m = hashlib.md5()
+        m.update(bytes(param.encode('utf-8')))
+        dig = m.hexdigest()
+        return dig
+
+    def set_sign(self, param):
+        dig = self.query_2_md5(param)
+        auth_string = self.encrypt(self.serect, dig)
+        cipher_text = base64.b64encode(auth_string)
+        cipher_str = str(cipher_text, encoding="utf-8")
+        sign = "%s %s" % (self.access_id, cipher_str)
+        return sign
 
 
-def encrypt(pub, original_text):  # 用公钥加密
-    pub = rsa.PublicKey.load_pkcs1_openssl_pem(pub)
-    crypt_text = rsa.encrypt(bytes(original_text.encode('utf-8')), pub)
-    return crypt_text  # 加密后的密文
+class xlyOpenApiRequest(xlyAuthorization):
+    """请求xly的openAPI"""
 
+    def get_method(self,
+                   url,
+                   param='',
+                   headers={"Content-Type": "application/json"}):
+        """
+        xly get http
+        """
+        req = requests.Request("GET", url, headers=headers).prepare()
+        sign = self.set_sign(param)
+        req.headers.update({'Authorization': sign})
+        res = self.session.send(req)
+        return res
 
-def query_2_md5(query_param):
-    m = hashlib.md5()
-    m.update(bytes(query_param.encode('utf-8')))
-    dig = m.hexdigest()
-    return dig
-
-
-def Sign(query_param):
-    dig = query_2_md5(query_param)
-    auth_string = encrypt(serect, dig)
-    cipher_text = base64.b64encode(auth_string)
-    cipher_str = str(cipher_text, encoding="utf-8")
-    sign = "%s %s" % (access_id, cipher_str)
-    return sign
-
-
-def Get_ipipe_auth(url):
-    session = requests.Session()
-    req = requests.Request(
-        "GET", url, headers={"Content-Type": "application/json"}).prepare()
-    query_param = ''
-    sign = Sign(query_param)
-    req.headers.update({'Authorization': sign})
-    return session, req
+    def post_method(self,
+                    url,
+                    data,
+                    param='',
+                    headers={"Content-Type": "application/json"}):
+        """
+        xly post http
+        """
+        req = requests.Request(
+            "POST", url, data=data, headers=headers).prepare()
+        sign = self.set_sign(self.param)
+        req.headers.update({'Authorization': sign})
+        res = self.session.send(req)
+        return res


### PR DESCRIPTION
- 增加两个http服务： 
   1. rerun server: /{user}/{repo}/{PR}/{commit}
   2. 常挂单测的列表：/faileduts
![image](https://user-images.githubusercontent.com/22937122/98799225-cd451000-2449-11eb-9906-140f1d580406.png)
- 重写xly鉴权服务

