### PR TITLE
optimization design in inform users

### DIFF
--- a/webservice/monitor/autoMarkTimeOutPR.py
+++ b/webservice/monitor/autoMarkTimeOutPR.py
@@ -140,6 +140,7 @@ class MarkTimeoutCI(object):
             "IPIPE-UID": "Paddle-bot"
         }
         for item in CIStatusList:
+            MARK_List = []
             PR = item['PR']
             commit = item['commit']
             ci_list = item['CI']
@@ -151,16 +152,19 @@ class MarkTimeoutCI(object):
                     res = xlyOpenApiRequest().post_method(
                         mark_url, json_str, headers=headers)
                     if res.status_code == 200 or res.status_code == 201:
+                        MARK_List.append(True)
                         print('%s_%s_%s mark success!' %
                               (PR, commit, ci['ciName']))
                         logger.error('%s_%s_%s mark success!' %
                                      (PR, commit, ci['ciName']))
                     else:
+                        MARK_List.append(False)
                         print('%s_%s_%s mark failed!' %
                               (PR, commit, ci['ciName']))
                         logger.error('%s_%s_%s mark failed!' %
                                      (PR, commit, ci['ciName']))
-            await self.inform(item)
+            if True in MARK_List:
+                await self.inform(item)
 
     async def inform(self, item):
         """Paddle-bot发出评论"""


### PR DESCRIPTION
优化标记CI失败后的通知模块：
   如何这个PR已经被标记过了，那么就不应该在给用户发出评论。
![image](https://user-images.githubusercontent.com/22937122/100302590-a6541580-2fd5-11eb-83d1-4048a4eaede9.png)
比如以上图片就不该发出两条评论。