### PR TITLE
CI耗时模块分析

### DIFF
--- a/webservice/monitor/ciConsumeTime_analysis.py
+++ b/webservice/monitor/ciConsumeTime_analysis.py
@@ -1,0 +1,206 @@
+import sys
+sys.path.append("..")
+from utils.db import Database
+from utils.common import CommonModule
+import datetime
+import time
+import numpy as np
+import math
+
+
+class ciIndex_dataAggregation():
+    """CI指标的数据聚合"""
+
+    def __init__(self, queryTime):
+        self.required_ci_list = [
+            'PR-CI-Coverage', 'PR-CI-Py3', 'PR-CI-Clone', 'PR-CI-Build',
+            'PR-CE-Framework', 'PR-CI-OP-benchmark', 'PR-CI-Model-benchmark',
+            'PR-CI-Static-Check', 'PR-CI-Inference', 'PR-CI-Mac-Python3',
+            'PR-CI-APPROVAL', 'PR-CI-Windows', 'PR-CI-Windows-OPENBLAS',
+            'PR-CI-Windows-Inference', 'PR-CI-musl', 'PR-CI-Kunlun',
+            'PR-CI-ROCM-Compile', 'PR-CI-NPU', 'PR-CI-GpuPS', 'PR-CI-CINN'
+        ]
+        self.db = Database()
+        self.common = CommonModule()
+        self.baseTimeIndex = ['waitTime_total', 'execTime_total']
+        self.detailTimeIndex = ['buildTime', 'testCaseTime_total']
+        self.startTime = self.common.strTimeToTimestamp(queryTime)
+        self.endTime = self.startTime + 86400
+
+    def timeIndex_rawdata(self, ciName, queryEvent, table='paddle_ci_status'):
+        if table == 'paddle_ci_status':
+            query_stat = "SELECT %s FROM paddle_ci_status where ciName='%s' and commit_createTime >= %s and commit_createTime < %s" % (
+                queryEvent, ciName, self.startTime, self.endTime)
+        elif table == 'paddle_ci_index':
+            query_stat = "SELECT %s FROM paddle_ci_index where ciName='%s' and createTime >= %s and createTime < %s" % (
+                queryEvent, ciName, self.startTime, self.endTime)
+        result = list(self.db.query(query_stat))
+        if len(result) == 0:
+            res = [None, None, None, None, None, None, None]
+        else:
+            time_list = []
+            for task in result[0]:
+                time_list.append(task[queryEvent] / 60)
+            time_list.sort(reverse=True)
+            max_time = round(time_list[0], 2)
+            timeList = np.array(time_list[0:math.ceil(len(time_list) * 0.1)])
+            mean_time_10 = round(float(np.mean(timeList)), 2)
+            timeList = np.array(time_list[0:math.ceil(len(time_list) * 0.3)])
+            mean_time_30 = round(float(np.mean(timeList)), 2)
+            timeList = np.array(time_list[0:math.ceil(len(time_list) * 0.5)])
+            mean_time_50 = round(float(np.mean(timeList)), 2)
+            timeList = np.array(time_list[0:math.ceil(len(time_list) * 0.7)])
+            mean_time_70 = round(float(np.mean(timeList)), 2)
+            timeList = np.array(time_list[0:math.ceil(len(time_list) * 0.9)])
+            mean_time_90 = round(float(np.mean(timeList)), 2)
+            timeList = np.array(time_list)
+            mean_time = round(float(np.mean(timeList)), 2)
+            res = [
+                max_time, mean_time_10, mean_time_30, mean_time_50,
+                mean_time_70, mean_time_90, mean_time
+            ]
+        return res
+
+    def dataAggregation(self):
+        """聚合"""
+        for ciName in self.required_ci_list:
+            print(ciName)
+            aggregation_data = {}
+            aggregation_data['ciName'] = ciName
+            aggregation_data['commit_createTime'] = self.startTime
+            #基础时间指标: 排队时间/执行时间
+            for ciindex in self.baseTimeIndex:
+                res = self.timeIndex_rawdata(ciName, ciindex)
+                max_time, mean_time_10, mean_time_30, mean_time_50, mean_time_70, mean_time_90, mean_time = res[
+                    0], res[1], res[2], res[3], res[4], res[5], res[6]
+                aggregation_data['%s_max_time' % ciindex] = max_time
+                aggregation_data['%s_mean_time_10' % ciindex] = mean_time_10
+                aggregation_data['%s_mean_time_30' % ciindex] = mean_time_30
+                aggregation_data['%s_mean_time_50' % ciindex] = mean_time_50
+                aggregation_data['%s_mean_time_70' % ciindex] = mean_time_70
+                aggregation_data['%s_mean_time_90' % ciindex] = mean_time_90
+                aggregation_data['%s_mean_time' % ciindex] = mean_time
+
+            #耗时=等待+执行
+            if aggregation_data['waitTime_total_mean_time'] == None:
+                if aggregation_data['execTime_total_mean_time'] == None:
+                    consumetime_total_max_time = None
+                    consumetime_total_mean_time_10 = None
+                    consumetime_total_mean_time_30 = None
+                    consumetime_total_mean_time_50 = None
+                    consumetime_total_mean_time_70 = None
+                    consumetime_total_mean_time_90 = None
+                    consumetime_total_mean_time = None
+                else:
+                    consumetime_total_max_time = round(
+                        aggregation_data['execTime_total_max_time'], 2)
+                    consumetime_total_mean_time_10 = round(
+                        aggregation_data['execTime_total_mean_time_10'], 2)
+                    consumetime_total_mean_time_30 = round(
+                        aggregation_data['execTime_total_mean_time_30'], 2)
+                    consumetime_total_mean_time_50 = round(
+                        aggregation_data['execTime_total_mean_time_50'], 2)
+                    consumetime_total_mean_time_70 = round(
+                        aggregation_data['execTime_total_mean_time_70'], 2)
+                    consumetime_total_mean_time_90 = round(
+                        aggregation_data['execTime_total_mean_time_90'], 2)
+                    consumetime_total_mean_time = round(
+                        aggregation_data['execTime_total_mean_time'], 2)
+            else:
+                if aggregation_data['execTime_total_mean_time'] == None:
+                    consumetime_total_max_time = round(
+                        aggregation_data['waitTime_total_max_time'], 2)
+                    consumetime_total_mean_time_10 = round(
+                        aggregation_data['waitTime_total_mean_time_10'], 2)
+                    consumetime_total_mean_time_30 = round(
+                        aggregation_data['waitTime_total_mean_time_30'], 2)
+                    consumetime_total_mean_time_50 = round(
+                        aggregation_data['waitTime_total_mean_time_50'], 2)
+                    consumetime_total_mean_time_70 = round(
+                        aggregation_data['waitTime_total_mean_time_70'], 2)
+                    consumetime_total_mean_time_90 = round(
+                        aggregation_data['execTime_total_mean_time_90'], 2)
+                    consumetime_total_mean_time = round(
+                        aggregation_data['waitTime_total_mean_time'], 2)
+                else:
+
+                    consumetime_total_max_time = round(
+                        aggregation_data['waitTime_total_max_time'] +
+                        aggregation_data['execTime_total_max_time'], 2)
+                    consumetime_total_mean_time_10 = round(
+                        aggregation_data['waitTime_total_mean_time_10'] +
+                        aggregation_data['execTime_total_mean_time_10'], 2)
+                    consumetime_total_mean_time_30 = round(
+                        aggregation_data['waitTime_total_mean_time_30'] +
+                        aggregation_data['execTime_total_mean_time_30'], 2)
+                    consumetime_total_mean_time_50 = round(
+                        aggregation_data['waitTime_total_mean_time_50'] +
+                        aggregation_data['execTime_total_mean_time_50'], 2)
+                    consumetime_total_mean_time_70 = round(
+                        aggregation_data['waitTime_total_mean_time_70'] +
+                        aggregation_data['execTime_total_mean_time_70'], 2)
+                    consumetime_total_mean_time_90 = round(
+                        aggregation_data['waitTime_total_mean_time_90'] +
+                        aggregation_data['execTime_total_mean_time_90'], 2)
+                    consumetime_total_mean_time = round(
+                        aggregation_data['waitTime_total_mean_time'] +
+                        aggregation_data['execTime_total_mean_time'], 2)
+
+            aggregation_data[
+                'consumetime_total_max_time'] = consumetime_total_max_time
+            aggregation_data[
+                'consumetime_total_mean_time_10'] = consumetime_total_mean_time_10
+            aggregation_data[
+                'consumetime_total_mean_time_30'] = consumetime_total_mean_time_30
+            aggregation_data[
+                'consumetime_total_mean_time_50'] = consumetime_total_mean_time_50
+            aggregation_data[
+                'consumetime_total_mean_time_70'] = consumetime_total_mean_time_70
+            aggregation_data[
+                'consumetime_total_mean_time_90'] = consumetime_total_mean_time_90
+            aggregation_data[
+                'consumetime_total_mean_time'] = consumetime_total_mean_timn
+            if None not in aggregation_data.values():
+                result = self.db.insert('paddle_ci_time_analysis',
+                                        aggregation_data)
+                print(result)
+
+    def getLongestTime(self):
+        consumetime_total_list = [
+            'consumetime_total_max_time', 'consumetime_total_mean_time_10',
+            'consumetime_total_mean_time_30', 'consumetime_total_mean_time_50',
+            'consumetime_total_mean_time_70', 'consumetime_total_mean_time_90',
+            'consumetime_total_mean_time'
+        ]
+        for queryEvent in consumetime_total_list:
+            result = {}
+            result['commit_createTime'] = self.startTime
+            query_stat = "SELECT TOP(%s, 1),ciName FROM paddle_ci_time_analysis where commit_createTime = %s" % (
+                queryEvent, self.startTime)
+            res = list(self.db.query(query_stat))
+            if len(res) != 0:
+                result['longest_%s' % queryEvent] = res[0][0]['top']
+                result['ciName'] = res[0][0]['ciName']
+                db_result = self.db.insert('paddle_ci_longest_time_table',
+                                           result)
+
+
+def getBetweenDay(begin_date, end_date=None):
+    begin_date = datetime.datetime.strptime(begin_date, "%Y-%m-%d")
+    if end_date == None:
+        end_date = datetime.datetime.strptime(
+            time.strftime('%Y-%m-%d', time.localtime(time.time())), "%Y-%m-%d")
+    else:
+        end_date = datetime.datetime.strptime(end_date, "%Y-%m-%d")
+    while begin_date <= end_date:
+        date_str = begin_date.strftime("%Y-%m-%d")
+        zeroToday = '%s 00:00:00' % date_str
+        ciindex = ciIndex_dataAggregation(zeroToday)
+        ciindex.dataAggregation()
+        ciindex.getLongestTime()
+        begin_date += datetime.timedelta(days=1)
+        time.sleep(3)
+
+
+if __name__ == "__main__":
+    getBetweenDay('2022-01-01', '2022-01-16')

--- a/webservice/monitor/ciConsumeTime_trend.py
+++ b/webservice/monitor/ciConsumeTime_trend.py
@@ -1,0 +1,232 @@
+import sys
+sys.path.append("..")
+from utils.db import Database
+from utils.common import CommonModule
+from flask import Flask
+from flask import request
+import json
+
+
+class ciIndexTrend():
+    def __init__(self, ciName, startTime, endTime):
+        self.db = Database()
+        self.common = CommonModule()
+        self.startTime = self.common.strTimeToTimestamp(startTime)
+        self.endTime = self.common.strTimeToTimestamp(endTime)
+        self.ciName = ciName
+        self.errorEXCODE = {
+            'NetWork Not Work': 503,
+            'Build Failed': 7,
+            'Test Failed': 8,
+            'CoverageRatio Failed': 9,
+            'Unknow Error': 1
+        }
+
+    def baseTime(self, queryEvent):
+        """查询时间"""
+        baseTime_dict = {
+            'waitTime_total': '平均排队时间',
+            'execTime_total': '平均执行时间'
+        }
+        query_string = '%s_max_time, %s_mean_time_10, %s_mean_time_30, %s_mean_time_50, %s_mean_time_70, %s_mean_time_90, %s_mean_time' % (
+            queryEvent, queryEvent, queryEvent, queryEvent, queryEvent,
+            queryEvent, queryEvent)
+        query_stat = "SELECT %s,commit_createTime FROM paddle_ci_time_analysis where ciName='%s' and commit_createTime >= %s and commit_createTime <= %s ORDER BY time" % (
+            query_string, self.ciName, self.startTime, self.endTime)
+        result = list(self.db.query(query_stat))
+        data = {}
+        categories = []
+        max_time_list = []
+        mean_time_10_list = []
+        mean_time_30_list = []
+        mean_time_50_list = []
+        mean_time_70_list = []
+        mean_time_90_list = []
+        mean_time_list = []
+        data['series'] = []
+        series = []
+        series_data1 = {}
+        series_data2 = {}
+        series_data3 = {}
+        series_data4 = {}
+        series_data5 = {}
+        series_data6 = {}
+        series_data7 = {}
+        for res in result[0]:
+            localtime = self.common.TimestampTostrTime(res[
+                'commit_createTime'])
+            categories.append(localtime)
+            max_time_list.append(res['%s_max_time' % queryEvent])
+            mean_time_10_list.append(res['%s_mean_time_10' % queryEvent])
+            mean_time_30_list.append(res['%s_mean_time_30' % queryEvent])
+            mean_time_50_list.append(res['%s_mean_time_50' % queryEvent])
+            mean_time_70_list.append(res['%s_mean_time_70' % queryEvent])
+            mean_time_90_list.append(res['%s_mean_time_90' % queryEvent])
+            mean_time_list.append(res['%s_mean_time' % queryEvent])
+        series_data1['name'] = '耗时最长'
+        series_data1['data'] = max_time_list
+        series.append(series_data1)
+        series_data2['name'] = '最长的前10%任务的平均耗时'
+        series_data2['data'] = mean_time_10_list
+        series.append(series_data2)
+        series_data3['name'] = '最长的前30%任务的平均耗时'
+        series_data3['data'] = mean_time_30_list
+        series.append(series_data3)
+        series_data4['name'] = '最长的前50%任务的平均耗时'
+        series_data4['data'] = mean_time_50_list
+        series.append(series_data4)
+        series_data5['name'] = '最长的前70%任务的平均耗时'
+        series_data5['data'] = mean_time_70_list
+        series.append(series_data5)
+        series_data6['name'] = '最长的前90%任务的平均耗时'
+        series_data6['data'] = mean_time_90_list
+        series.append(series_data6)
+        series_data7['name'] = '平均耗时'
+        series_data7['data'] = mean_time_list
+        series.append(series_data7)
+        data['categories'] = categories
+        data['series'] = series
+        res = {"status": 0, "msg": "", "data": data}
+        return res
+
+    def getLongestTime(self):
+        max_time_list = []
+        data = {}
+        series = []
+        consumetime_total_dict = {
+            'longest_consumetime_total_max_time': [],
+            'longest_consumetime_total_mean_time_10': [],
+            'longest_consumetime_total_mean_time_30': [],
+            'longest_consumetime_total_mean_time_50': [],
+            'longest_consumetime_total_mean_time_70': [],
+            'longest_consumetime_total_mean_time_90': [],
+            'longest_consumetime_total_mean_time': []
+        }
+        consumetime_total_value_dict = {
+            'longest_consumetime_total_max_time': '耗时最长',
+            'longest_consumetime_total_mean_time_10': '最长的前10%任务的平均耗时',
+            'longest_consumetime_total_mean_time_30': '最长的前30%任务的平均耗时',
+            'longest_consumetime_total_mean_time_50': '最长的前50%任务的平均耗时',
+            'longest_consumetime_total_mean_time_70': '最长的前70%任务的平均耗时',
+            'longest_consumetime_total_mean_time_90': '最长的前90%任务的平均耗时',
+            'longest_consumetime_total_mean_time': '平均耗时'
+        }
+
+        consumetime_total_list = [
+            'consumetime_total_max_time', 'consumetime_total_mean_time_10',
+            'consumetime_total_mean_time_30', 'consumetime_total_mean_time_50',
+            'consumetime_total_mean_time_70', 'consumetime_total_mean_time_90',
+            'consumetime_total_mean_time'
+        ]
+        for queryEvent in consumetime_total_list:
+            categories = []
+            queryEvent = 'longest_%s' % queryEvent
+            query_stat = "SELECT %s,ciName,commit_createTime FROM paddle_ci_longest_time_table where commit_createTime >= %s and commit_createTime <= %s ORDER BY time" % (
+                queryEvent, self.startTime, self.endTime)
+            result = list(self.db.query(query_stat))
+            for event in result[0]:
+                if event[queryEvent] != None:
+                    localtime = self.common.TimestampTostrTime(event[
+                        'commit_createTime'])
+                    categories.append(localtime)
+                    consumetime_total_dict[queryEvent].append(event[
+                        queryEvent])
+        data['categories'] = categories
+        for index in consumetime_total_dict:
+            series_data = {}
+            series_data['name'] = consumetime_total_value_dict[index]
+            series_data['data'] = consumetime_total_dict[index]
+            series.append(series_data)
+        data['series'] = series
+        res = {"status": 0, "msg": "", "data": data}
+        return res
+
+    def getLongestTimeTable(self):
+        columns = [{
+            "name": "时间",
+            "id": "time"
+        }, {
+            "name": "",
+            "id": "key"
+        }, {
+            "name": "ciName",
+            "id": "ciName"
+        }, {
+            "name": "平均耗时",
+            "id": "consume_time"
+        }]
+        row = []
+        consumetime_total_list = ['consumetime_total_mean_time']
+        query_stat = "SELECT longest_consumetime_total_mean_time,ciName,commit_createTime FROM paddle_ci_longest_time_table where commit_createTime >= %s and commit_createTime <= %s ORDER BY time" % (
+            self.startTime, self.endTime)
+        result = list(self.db.query(query_stat))
+        for event in result[0]:
+            if event[queryEvent] != None:
+                localtime = self.common.TimestampTostrTime(event[
+                    'commit_createTime'])
+                categories.append(localtime)
+                consumetime_total_dict[queryEvent].append(event[queryEvent])
+        data['categories'] = categories
+        for index in consumetime_total_dict:
+            series_data = {}
+            series_data['name'] = consumetime_total_value_dict[index]
+            series_data['data'] = consumetime_total_dict[index]
+            series.append(series_data)
+        data['series'] = series
+        res = {"status": 0, "msg": "", "data": data}
+        return res
+
+
+app = Flask(__name__)
+
+
+@app.route('/ciindex_analysis', methods=['POST'])
+def analysis_arguments():
+    arguments = json.loads(request.data)
+    for i in arguments['conditions']:
+        if i['k'] == 'select':
+            ciName = i['v']
+        elif i['k'] == 'dateRange':
+            dateRange = i['v']
+            startTime = '%s 00:00:00' % dateRange.split(',')[0]
+            endTime = '%s 00:00:00' % dateRange.split(',')[1]
+    return ciName, startTime, endTime
+
+
+@app.route('/ciindex_analysis/waittime', methods=['POST'])
+def waittime_api():
+    ciName, startTime, endTime = analysis_arguments()
+    ciIndex_trend = ciIndexTrend(ciName, startTime, endTime)
+    waitTime_data = ciIndex_trend.baseTime('waitTime_total')
+    data = waitTime_data
+    return data
+
+
+@app.route('/ciindex_analysis/exectime', methods=['POST'])
+def exectime_api():
+    ciName, startTime, endTime = analysis_arguments()
+    ciIndex_trend = ciIndexTrend(ciName, startTime, endTime)
+    execTime_data = ciIndex_trend.baseTime('execTime_total')
+    data = execTime_data
+    return data
+
+
+@app.route('/ciindex_analysis/consumetime', methods=['POST'])
+def consumetime_api():
+    ciName, startTime, endTime = analysis_arguments()
+    ciIndex_trend = ciIndexTrend(ciName, startTime, endTime)
+    consumeTime_data = ciIndex_trend.baseTime('consumetime_total')
+    return consumeTime_data
+
+
+@app.route('/ciindex_analysis/longesttime', methods=['POST'])
+def longesttime_api():
+    ciName, startTime, endTime = analysis_arguments()
+    ciIndex_trend = ciIndexTrend(ciName, startTime, endTime)
+    longesttime_data = ciIndex_trend.getLongestTime()
+    data = longesttime_data
+    return data
+
+
+if __name__ == '__main__':
+    app.run(host='xx:xx:xx:xx', port=8096)


### PR DESCRIPTION
将CI任务耗时时间从高到低排序，分为：
1. 最长耗时的任务
2. 耗时前10%的任务平均时间
3. 耗时前30%的任务平均时间
4. 耗时前50%的任务平均时间
5. 耗时前70%的任务平均时间
6. 耗时前90%的任务平均时间
7. 所有任务的平均耗时